### PR TITLE
fix(scale): Process full datasets for Table View

### DIFF
--- a/e2e/tests/app.spec.ts
+++ b/e2e/tests/app.spec.ts
@@ -26,8 +26,7 @@ test('render dataSets on the homepage', async ({ page }) => {
 
 test('render chart page with data', async ({ page }) => {
   // Visit the chart page
-  await page.goto('/chart/lottery-powerball-winning-numbers');
-
+  await page.goto('/chart/lottery-powerball-winning-numbers?page=1&pageSize=100');
   // Expect chart page title to render
   await expect(
     page.locator('text=Winning numbers for the Powerball lottery game in New York'),

--- a/src/app/chart/[name]/page.tsx
+++ b/src/app/chart/[name]/page.tsx
@@ -7,13 +7,30 @@ type ChartPageProps = Promise<{ name: string }>;
 /**
  * Render Chart page where users may view data or create a new chart View
  */
-export default async function ChartPage({ params }: { params: ChartPageProps }) {
-  const { name } = await params;
+export default async function ChartPage({ 
+  params,
+  searchParams 
+}: { 
+  params: ChartPageProps;
+  searchParams: { page?: string; pageSize?: string };
+}) {
+  const { name  } = await params;
+  const { page: pageParam, pageSize: pageSizeParam } = await searchParams;
+  const page = Number(pageParam) || 1;
+  const pageSize = Number(pageSizeParam) || 100;
+  
   const dataSetItem = await getOrCreateDataset(name);
   const url = dataSetItem ? dataSetItem.downloadUrl : '';
-  const { rows, columns } = await getData(name, url);
+  const { rows, columns, totalCount } = await getData(name, url, page, pageSize);
 
   return (
-    <ChartPageView dataSetItem={dataSetItem} columns={dataSetItem.columns ?? columns} rows={rows} />
+    <ChartPageView 
+      page={page}
+      pageSize={pageSize}
+      dataSetItem={dataSetItem} 
+      columns={dataSetItem.columns ?? columns} 
+      rows={rows} 
+      totalCount={totalCount}
+    />
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,23 +4,25 @@ import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import './globals.css';
 import Theme from '@/providers/Theme';
 
-/* istanbul ignore next */
 const barlow = Barlow({
   subsets: ['latin'],
   weight: ['300', '400', '600'],
   variable: '--font-barlow',
+  display: 'swap',
 });
-/* istanbul ignore next */
+
 const barlowcondensed = Barlow_Semi_Condensed({
   subsets: ['latin'],
   weight: ['300', '400', '600'],
   variable: '--font-barlow-condensed',
+  display: 'swap',
 });
-/* istanbul ignore next */
+
 const spacemono = Space_Mono({
   subsets: ['latin'],
   weight: ['400'],
   variable: '--font-space-mono',
+  display: 'swap',
 });
 
 export const metadata: Metadata = {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image';
 import styles from './page.module.scss';
 import DataSetList from '@/components/DataSetList';
 import getDataSets from '@/utils/get-datasets';
+import Link from 'next/link';
 
 export default async function Home() {
   const dataSetList = await getDataSets();
@@ -9,7 +10,9 @@ export default async function Home() {
     <main className={styles.main}>
       <section className="title-panel">
         <div className="title">
-          <Image src="/logo.png" alt="data thing" width={400} height={100} priority />
+          <Link href="/">
+            <Image src="/logo.png" alt="data thing" width={400} height={100} priority />
+          </Link>
           <p>
             another chart app project
             <br />

--- a/src/components/DataSetList/index.tsx
+++ b/src/components/DataSetList/index.tsx
@@ -18,7 +18,7 @@ const renderDataSet = (dataset: DataSetRaw) => {
   }).format(new Date(dataset.metadata_modified));
 
   return (
-    <Link key={dataset.name} className="dataset" href={`/chart/${dataset.name}`}>
+    <Link key={dataset.name} className="dataset" href={`/chart/${dataset.name}?page=1&pageSize=100`}>
       <h3>{dataset.title}</h3>
       <div className="dataset-metadata">
         <h4>{`${dataset.organization.title} - ${dataset.maintainer}`}</h4>

--- a/src/components/DataSetList/index.tsx
+++ b/src/components/DataSetList/index.tsx
@@ -6,6 +6,8 @@ type DataSetListProps = {
   dataSetList: DataSetRaw[];
 };
 
+const DEFAULT_PAGE_SIZE = 100;
+
 /**
  * Render each dataset displaying the title, modified date, maintaining agency, and description.
  * Link to each dataset's Chart page on click, determined by the dataset name.
@@ -18,7 +20,7 @@ const renderDataSet = (dataset: DataSetRaw) => {
   }).format(new Date(dataset.metadata_modified));
 
   return (
-    <Link key={dataset.name} className="dataset" href={`/chart/${dataset.name}?page=1&pageSize=100`}>
+    <Link key={dataset.name} className="dataset" href={`/chart/${dataset.name}?page=1&pageSize=${DEFAULT_PAGE_SIZE}`}>
       <h3>{dataset.title}</h3>
       <div className="dataset-metadata">
         <h4>{`${dataset.organization.title} - ${dataset.maintainer}`}</h4>

--- a/src/components/DisplayChart/index.tsx
+++ b/src/components/DisplayChart/index.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { GridColDef, GridValidRowModel } from '@mui/x-data-grid';
+import { GridColDef, GridValidRowModel, GridPaginationModel } from '@mui/x-data-grid';
 import { ViewConfig } from '@/types/viewConfig';
 import BarChartView from '@/components/BarChartView';
 import TableView from '@/components/TableView';
@@ -9,6 +9,9 @@ type DisplayChartProps = {
   filteredColumns: GridColDef[];
   filteredRows: GridValidRowModel[];
   loading: boolean;
+  totalCount: number;
+  paginationModel: GridPaginationModel;
+  onPaginationModelChange: (model: GridPaginationModel) => void;
 };
 
 /**
@@ -20,6 +23,9 @@ const DisplayChart = memo(function DisplayChart({
   filteredColumns,
   filteredRows,
   loading,
+  totalCount,
+  paginationModel,
+  onPaginationModelChange,
 }: DisplayChartProps) {
   return {
     bar: (
@@ -36,6 +42,9 @@ const DisplayChart = memo(function DisplayChart({
         columns={filteredColumns}
         rows={filteredRows}
         loading={loading}
+        totalCount={totalCount}
+        paginationModel={paginationModel}
+        onPaginationModelChange={onPaginationModelChange}
       />
     ),
     default: <div>View not supported</div>,

--- a/src/components/TableView/index.tsx
+++ b/src/components/TableView/index.tsx
@@ -1,22 +1,38 @@
-import { DataGrid, GridColDef, GridValidRowModel } from '@mui/x-data-grid';
+import { DataGrid, GridColDef, GridValidRowModel, GridPaginationModel } from '@mui/x-data-grid';
 
 type TableViewProps = {
   viewId: string;
   columns: GridColDef[];
   rows: GridValidRowModel[];
   loading: boolean;
+  totalCount: number;
+  onPaginationModelChange?: (model: GridPaginationModel) => void;
+  paginationModel?: GridPaginationModel;
 };
 
 /**
  * Render tabular View for dataset
  */
-export default function TableView({ viewId, columns, rows, loading }: TableViewProps) {
+export default function TableView({ 
+  viewId, 
+  columns, 
+  rows, 
+  loading, 
+  totalCount,
+  onPaginationModelChange,
+  paginationModel = { page: 0, pageSize: 100 }
+}: TableViewProps) {
   return (
     <DataGrid
       key={`data-grid-${viewId}`}
       rows={rows}
       columns={columns}
       loading={loading}
+      rowCount={totalCount}
+      paginationMode="server"
+      paginationModel={paginationModel}
+      onPaginationModelChange={onPaginationModelChange}
+      pageSizeOptions={[100]}
       slotProps={{
         loadingOverlay: {
           variant: 'skeleton',

--- a/src/utils/get-data.ts
+++ b/src/utils/get-data.ts
@@ -17,7 +17,6 @@ export default async function getData(name: string, url: string | null, page: nu
     let cursor = null;
     const collection = db.collection(shortCode);
     const totalCount = await collection.estimatedDocumentCount();
-
     if (totalCount <= page * pageSize) {
       cursor = await collection.find({});
     } else {
@@ -47,7 +46,7 @@ export default async function getData(name: string, url: string | null, page: nu
     // update dataset record with column info
     const datasetList = await db.collection('dataset_catalog');
     const record = await datasetList.findOne({ name: shortCode });
-    if (record && record.columns.length) {
+    if (record && !record.columns) {
       await datasetList.updateOne({ name: shortCode }, { $set: { columns } });
     }
 

--- a/src/utils/get-data.ts
+++ b/src/utils/get-data.ts
@@ -3,42 +3,71 @@
 import db from '@/db';
 import { formatTabularDataCsv } from './formatTabularData';
 import { getShortcode } from './string-util';
+import { GridValidRowModel } from '@mui/x-data-grid';
 
 /** Download dataset from given resource url */
-export default async function getData(name: string, url: string | null) {
-  if (!url) return { rows: [], columns: [] };
+export default async function getData(name: string, url: string | null, page: number = 1, pageSize: number = 100) {
+  if (!url) return { rows: [], columns: [], totalCount: 0 };
 
   const shortCode = getShortcode(name);
 
   const collections = await db.listCollections({ nameOnly: true });
-  // if collection exists, return from db
+
   if (collections.includes(shortCode)) {
-    const cursor = await db.collection(shortCode).find({});
-    const rows = await cursor.toArray();
-    return { rows: rows, columns: [] };
+    let cursor = null;
+    const collection = db.collection(shortCode);
+    const totalCount = await collection.estimatedDocumentCount();
+
+    if (totalCount <= page * pageSize) {
+      cursor = await collection.find({});
+    } else {
+      // Find documents with a sequential id for a given page and pageSize.
+      // (workaround for paginating large datasets within the limits of the free tier)
+      cursor = await collection.find({ id: { $gte: page * pageSize, $lt: (page + 1) * pageSize } })
+    }
+
+    const rows = await cursor.toArray()
+    return { rows, columns: [], totalCount };
   }
 
-  const data = await fetch(url, {
-    method: 'GET',
-    cache: 'no-store',
-  })
-    .then(res => res.text())
-    .then(csv => formatTabularDataCsv(csv))
-    .catch(err => console.log(err));
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      cache: 'no-store',
+    });
 
-  if (data) {
+    const csv = await response.text();
+    const { columns, processBatch } = formatTabularDataCsv(csv);
+
+    if (!processBatch) {
+      console.error('Failed to initialize data processing');
+      return { rows: [], columns: [], totalCount: 0 };
+    }
+
     // update dataset record with column info
     const datasetList = await db.collection('dataset_catalog');
     const record = await datasetList.findOne({ name: shortCode });
-    if (record) {
-      await datasetList.updateOne({ name: shortCode }, { $set: { columns: data.columns } });
+    if (record && record.columns.length) {
+      await datasetList.updateOne({ name: shortCode }, { $set: { columns } });
     }
+
     const collection = await db.createCollection(shortCode);
+    const batchSize = 100;
+    let processedRows = 0;
 
-    collection.insertMany(data.rows);
-  } else {
-    return { rows: [], columns: [] };
+    // process and insert batches
+    let firstBatch: GridValidRowModel[] = [];
+    for (const batch of processBatch(batchSize)) {
+      await collection.insertMany(batch);
+      processedRows += batch.length;
+      if (firstBatch.length === 0) {
+        firstBatch = batch;
+      }
+    }
+
+    return { rows: firstBatch, columns, totalCount: processedRows };
+  } catch (err) {
+    console.error('Error processing data:', err);
+    return { rows: [], columns: [], totalCount: 0 };
   }
-
-  return { rows: data.rows, columns: data.columns };
 }


### PR DESCRIPTION
- update get-data to process data in batches
	- remove 100 record limit
	- update formatTabularData to return generator function that processes data in chunks of 100 records
- add pagination to table view
	- filter for data by sequential id
	  - *workaround for datastax free tier where pagination is a paid feature
	- add page and pagesize to searchparams
	- update chart page test
- misc
	- fix fonts
	- add link to logo
